### PR TITLE
Wav2vec2 docstring refers wrongly to EBEN

### DIFF
--- a/vibravox/lightning_modules/wav2vec2_for_stp.py
+++ b/vibravox/lightning_modules/wav2vec2_for_stp.py
@@ -19,7 +19,7 @@ class Wav2Vec2ForSTPLightningModule(LightningModule):
         push_to_hub_after_testing: bool = False,
     ):
         """
-        Definition of EBEN and its training pipeline with pytorch lightning paradigm
+        Definition of Wav2Vec2ForSTP and its training pipeline with pytorch lightning paradigm
 
         Args:
             sample_rate (int): Sample rate of the audio


### PR DESCRIPTION
fixes https://github.com/jhauret/vibravox/issues/12