### PR TITLE
Use mix_speech_and_noise_without_rescaling

### DIFF
--- a/configs/lightning_datamodule/noisybwe.yaml
+++ b/configs/lightning_datamodule/noisybwe.yaml
@@ -8,10 +8,6 @@ collate_strategy: "constant_length-2500-ms"
 streaming: False
 batch_size: 32
 num_workers: 4
-snr_range:
-  _target_: builtins.tuple
-  _args_:
-    - [-3.0, 5.0]
 
 # This is not used in the actual classes, but just for the description and hydra run directory
 id: ${lightning_datamodule.sensor}

--- a/vibravox/lightning_datamodules/noisybwe.py
+++ b/vibravox/lightning_datamodules/noisybwe.py
@@ -208,7 +208,7 @@ class NoisyBWELightningDataModule(LightningDataModule):
         """
         Custom data collator function to mix speech and noise audios and dynamically pad the data.
 
-        This function processes a batch of data by mixing clean speech with noise at specified SNR ranges.
+        This function processes a batch of data by mixing clean speech with noise.
         It then pads or trims the audio signals based on the collate strategy and applies data augmentation
         if specified.
 

--- a/vibravox/lightning_datamodules/noisybwe.py
+++ b/vibravox/lightning_datamodules/noisybwe.py
@@ -6,7 +6,7 @@ from datasets import Audio, load_dataset
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 from lightning import LightningDataModule
-from vibravox.utils import mix_speech_and_noise_with_rescaling
+from vibravox.utils import mix_speech_and_noise_without_rescaling
 from vibravox.utils import set_audio_duration
 from vibravox.torch_modules.dsp.data_augmentation import WaveformDataAugmentation
 from vibravox.datasets.speech_noise import SpeechNoiseDataset
@@ -23,7 +23,6 @@ class NoisyBWELightningDataModule(LightningDataModule):
         streaming: bool = False,
         batch_size: int = 32,
         num_workers: int = 4,
-        snr_range: Tuple[float] = (-3.0, 5.0),
         **kwargs,
     ):
         """
@@ -43,7 +42,6 @@ class NoisyBWELightningDataModule(LightningDataModule):
             streaming (bool, optional): If True, the audio files are dynamically downloaded. Defaults to False.
             batch_size (int, optional): Batch size. Defaults to 32.
             num_workers (int, optional): Number of workers. Defaults to 4.
-            snr_range (Tuple[float], optional): SNR range for the noising. Defaults to [-3.0, 5.0].
         """
         super().__init__()
         
@@ -67,7 +65,6 @@ class NoisyBWELightningDataModule(LightningDataModule):
         self.streaming = streaming
         self.batch_size = batch_size
         self.num_workers = num_workers
-        self.snr_range = snr_range
         
     def setup(self, stage: str = None) -> None:
         """
@@ -242,7 +239,7 @@ class NoisyBWELightningDataModule(LightningDataModule):
         air_conducted_batch = [item["audio_airborne"]["array"] for item in batch]
         noise_batch = [item["audio_body_conducted_speechless_noisy"]["array"] for item in batch] # len(noise_batch) > len(body_conducted_batch)
         
-        speech_noisy_synthetic, _ = mix_speech_and_noise_with_rescaling(body_conducted_batch, noise_batch, self.snr_range)
+        speech_noisy_synthetic, _ = mix_speech_and_noise_without_rescaling(body_conducted_batch, noise_batch)
         
         if collate_strategy == "pad":
 


### PR DESCRIPTION
This pull request to `vibravox/lightning_datamodules/noisybwe.py` includes changes to modify the mixing function used for speech and noise, and to remove the `snr_range` parameter from the initialization and related methods. The most important changes include updating the import for the mixing function, removing the `snr_range` parameter from the `__init__` method, and updating the data collator method to use the new mixing function.

Changes to mixing function:

* [`vibravox/lightning_datamodules/noisybwe.py`](diffhunk://#diff-28250dfff81ed38b749ee322eb3a001323ccc2e42f1fa9491a47a1283e25a8eeL9-R9): Updated import to use `mix_speech_and_noise_without_rescaling` instead of `mix_speech_and_noise_with_rescaling`.
* [`vibravox/lightning_datamodules/noisybwe.py`](diffhunk://#diff-28250dfff81ed38b749ee322eb3a001323ccc2e42f1fa9491a47a1283e25a8eeL245-R242): Updated `data_collator` method to use `mix_speech_and_noise_without_rescaling` instead of `mix_speech_and_noise_with_rescaling`.

Removal of `snr_range` parameter:

* [`vibravox/lightning_datamodules/noisybwe.py`](diffhunk://#diff-28250dfff81ed38b749ee322eb3a001323ccc2e42f1fa9491a47a1283e25a8eeL26): Removed `snr_range` parameter from the `__init__` method signature.
* [`vibravox/lightning_datamodules/noisybwe.py`](diffhunk://#diff-28250dfff81ed38b749ee322eb3a001323ccc2e42f1fa9491a47a1283e25a8eeL46): Removed `snr_range` parameter from the `__init__` method docstring.
* [`vibravox/lightning_datamodules/noisybwe.py`](diffhunk://#diff-28250dfff81ed38b749ee322eb3a001323ccc2e42f1fa9491a47a1283e25a8eeL70): Removed assignment of `snr_range` in the `__init__` method.