### PR TITLE
Fix the audio logging behavior

### DIFF
--- a/vibravox/lightning_modules/eben.py
+++ b/vibravox/lightning_modules/eben.py
@@ -357,19 +357,19 @@ class EBENLightningModule(LightningModule):
         if (batch_idx < 15 and self.logger and self.num_val_runs > 1) or stage == "test":
             self.log_audio(
                 audio_tensor=outputs["enhanced"],
-                tag=f"{stage}_{dataloader_idx}_{batch_idx}/enhanced",
+                tag=f"{stage}{"_"+self.dataloader_names[dataloader_idx] if self.dataloader_names is not None else ""}_{batch_idx}/enhanced",
                 global_step=self.num_val_runs,
             )
             if self.num_val_runs == 2 or stage == "test":  # 2 because first one is a sanity check in lightning
                 if "reference" in outputs: # {val, test}_dataset_real does not have any reference audio
                     self.log_audio(
                         audio_tensor=outputs["reference"],
-                        tag=f"{stage}_{dataloader_idx}_{batch_idx}/reference",
+                        tag=f"{stage}{"_"+self.dataloader_names[dataloader_idx] if self.dataloader_names is not None else ""}_{batch_idx}/reference",
                         global_step=self.num_val_runs,
                     )
                 self.log_audio(
                     audio_tensor=outputs["corrupted"],
-                    tag=f"{stage}_{dataloader_idx}_{batch_idx}/corrupted",
+                    tag=f"{stage}{"_"+self.dataloader_names[dataloader_idx] if self.dataloader_names is not None else ""}_{batch_idx}/corrupted",
                     global_step=self.num_val_runs,
                 )
 

--- a/vibravox/utils.py
+++ b/vibravox/utils.py
@@ -226,7 +226,7 @@ def mix_speech_and_noise_without_rescaling(
         raise ValueError("speech_batch and noise_batch must have the same length")
 
     corrupted_speech_batch: List[torch.Tensor] = []
-    noise_batch: List[torch.Tensor] = []
+    non_scaled_noise_batch: List[torch.Tensor] = []
 
     for speech, noise in zip(speech_batch, noise_batch):
         
@@ -249,9 +249,9 @@ def mix_speech_and_noise_without_rescaling(
         corrupted_speech = speech + noise_sliced
 
         corrupted_speech_batch.append(corrupted_speech)
-        noise_batch.append(noise_sliced)
+        non_scaled_noise_batch.append(noise_sliced)
 
-    return corrupted_speech_batch, noise_batch
+    return corrupted_speech_batch, non_scaled_noise_batch
 
 def decode_operations(predicted_chr: str,
                       label_chr: str,


### PR DESCRIPTION
Previously, audios were logged with `dataloader_idx`, which is not really informative about the dataset being validated/tested on.
Now it's been changed to log the `dataloader_name`. 

Also, a small fix in `mix_speech_and_noise_without_rescaling` has been done.