### PR TITLE
Log only the 15 first audios in testing

### DIFF
--- a/vibravox/lightning_modules/eben.py
+++ b/vibravox/lightning_modules/eben.py
@@ -354,7 +354,7 @@ class EBENLightningModule(LightningModule):
         )
 
         # Log audio
-        if (batch_idx < 15 and self.logger and self.num_val_runs > 1) or stage == "test":
+        if (batch_idx < 15 and self.logger and self.num_val_runs > 1) or (stage == "test" and batch_idx < 15):
             self.log_audio(
                 audio_tensor=outputs["enhanced"],
                 tag=f"{stage}_{self.dataloader_names[dataloader_idx] if self.dataloader_names is not None else ''}_{batch_idx}/enhanced",


### PR DESCRIPTION
This pull request includes a small but important change to the `common_eval_logging` method in the `vibravox/lightning_modules/eben.py` file. The change ensures that audio logging during the test stage is only performed for batches with an index less than 15.

* [`vibravox/lightning_modules/eben.py`](diffhunk://#diff-721c413b7795446d81c9be647b812355e6afc15525094609c27ec0bb1dd5020aL357-R357): Modified the condition in the `common_eval_logging` method to restrict audio logging during the test stage to batches with an index less than 15.

Tested on kraken : https://kraken.cnam.fr/tensorboard4