### PR TITLE
Add checkpoint options to the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python run.py lightning_datamodule=bwe lightning_datamodule.sensor=throat_microp
 
 - Train [EBEN](https://github.com/jhauret/eben) for Bandwidth Extension _with Noise_
 ```
-python run.py lightning_datamodule=noisybwe lightning_datamodule.sensor=throat_microphone lightning_module=eben  ++trainer.check_val_every_n_epoch=15 ++trainer.max_epochs=500
+python run.py lightning_datamodule=noisybwe lightning_datamodule.sensor=throat_microphone lightning_module=eben ++callbacks=bwe_checkpoint 'checkpoint.monitor=validation\/torchmetrics_stoi\/synthetic' ++trainer.check_val_every_n_epoch=15 ++trainer.max_epochs=500
 ```
 
 - Train [wav2vec2](https://huggingface.co/facebook/wav2vec2-base-fr-voxpopuli-v2) for Speech to Phoneme  

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Speech to Phoneme, Bandwidth Extension and Speaker Verification using the Vibrav
 
 - Train [EBEN](https://github.com/jhauret/eben) for Bandwidth Extension  
 ```
-python run.py lightning_datamodule=bwe lightning_datamodule.sensor=throat_microphone lightning_module=eben  lightning_module.generator.p=2 ++trainer.check_val_every_n_epoch=15 ++trainer.max_epochs=500
+python run.py lightning_datamodule=bwe lightning_datamodule.sensor=throat_microphone lightning_module=eben +callbacks=[bwe_checkpoint] lightning_module.generator.p=2 ++trainer.check_val_every_n_epoch=15 ++trainer.max_epochs=500
 ```
 
 - Train [EBEN](https://github.com/jhauret/eben) for Bandwidth Extension _with Noise_
 ```
-python run.py lightning_datamodule=noisybwe lightning_datamodule.sensor=throat_microphone lightning_module=eben ++callbacks=bwe_checkpoint 'checkpoint.monitor=validation\/torchmetrics_stoi\/synthetic' ++trainer.check_val_every_n_epoch=15 ++trainer.max_epochs=500
+python run.py lightning_datamodule=noisybwe lightning_datamodule.sensor=throat_microphone lightning_module=eben +callbacks=[bwe_checkpoint] ++"callbacks.checkpoint.monitor=validation/torchmetrics_stoi/synthetic" ++trainer.check_val_every_n_epoch=15 ++trainer.max_epochs=500
 ```
 
 - Train [wav2vec2](https://huggingface.co/facebook/wav2vec2-base-fr-voxpopuli-v2) for Speech to Phoneme  

--- a/configs/callbacks/bwe_checkpoint.yaml
+++ b/configs/callbacks/bwe_checkpoint.yaml
@@ -1,6 +1,6 @@
 checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
-  monitor: "validation/torchmetrics_stoi/dataloader_idx_0" # name of the logged metric which determines when model is improving
+  monitor: "validation/torchmetrics_stoi" # name of the logged metric which determines when model is improving
   mode: "max" # "max" means higher metric value is better, can be also "min"
   save_top_k: 2 # save k best model (determined by above metric)
   save_last: True # additionally, always save model from last epoch

--- a/configs/callbacks/bwe_checkpoint.yaml
+++ b/configs/callbacks/bwe_checkpoint.yaml
@@ -1,6 +1,6 @@
 checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
-  monitor: "validation/torchmetrics_stoi" # name of the logged metric which determines when model is improving
+  monitor: "validation/torchmetrics_stoi/" # name of the logged metric which determines when model is improving
   mode: "max" # "max" means higher metric value is better, can be also "min"
   save_top_k: 2 # save k best model (determined by above metric)
   save_last: True # additionally, always save model from last epoch

--- a/configs/run.yaml
+++ b/configs/run.yaml
@@ -18,7 +18,6 @@ defaults:
   - lightning_module: null # NEEDS TO BE OVERRIDDEN
   - trainer: ddp
   - callbacks: # Dict of callbacks
-      # - bwe_checkpoint
       - rich_model_summary
   - logging: tensorboard
   - metrics: ${lightning_datamodule}

--- a/configs/run.yaml
+++ b/configs/run.yaml
@@ -17,7 +17,7 @@ defaults:
   - lightning_datamodule: null # NEEDS TO BE OVERRIDDEN, will also determinate the metrics and the run directory
   - lightning_module: null # NEEDS TO BE OVERRIDDEN
   - trainer: ddp
-  - callbacks: # Dict of callbacks
+  - callbacks: # List of callbacks
       - rich_model_summary
   - logging: tensorboard
   - metrics: ${lightning_datamodule}


### PR DESCRIPTION
This pull request includes updates to the training scripts, configuration files, and default settings for the `Speech to Phoneme, Bandwidth Extension and Speaker Verification using the Vibravox` project. The most important changes include adding a new callback for model checkpointing, updating the metric monitored by the checkpoint callback, and modifying the default callback configuration.

Updates to training scripts:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R40): Added the `bwe_checkpoint` callback to the training commands for both Bandwidth Extension and Bandwidth Extension with Noise.

Configuration file updates:

* [`configs/callbacks/bwe_checkpoint.yaml`](diffhunk://#diff-be3b8434b89b347191fae601ccd4db9864d450a36ac108f9fc1ffd16b7df2aa4L3-R3): Changed the monitored metric in the checkpoint callback from `"validation/torchmetrics_stoi/dataloader_idx_0"` to `"validation/torchmetrics_stoi"` by default.

Default settings modifications:

* [`configs/run.yaml`](diffhunk://#diff-d253e4e5e9d62fee5fdb466df5f57e3ba5a423322d43913d53ec9f085c79724aL20-R20): Updated the `callbacks` section to list `rich_model_summary` and removed the commented-out `bwe_checkpoint` entry.

Tested thoroughly and works.

**Beware**
A bug has been detected : test phase does not work with checkpointing callback because of custom VibraVox metrics like `noresqa_mos` or `torchsquims_toi` -> need to raise another PR to fix that bug.